### PR TITLE
rats-tls: fix sgx build mode error

### DIFF
--- a/src/attesters/CMakeLists.txt
+++ b/src/attesters/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(nullattester)
 
-if(EXISTS "/usr/include/linux/sev-guest.h")
+if((EXISTS "/usr/include/linux/sev-guest.h") AND HOST)
     add_subdirectory(sev-snp)
 endif()
 

--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -181,6 +181,7 @@ bool is_tdguest_supported(void)
 	return (sig[1] == 0x65746e49) && (sig[3] == 0x5844546c) && (sig[2] == 0x20202020);
 }
 
+#ifndef SGX
 /* rdmsr 0xc0010131
  * bit[0]
  * 	0 = Guest SEV is not active;
@@ -211,9 +212,14 @@ static uint64_t read_msr(uint32_t reg)
 
 	return data;
 }
+#endif
 
 /* check whether running in AMD SEV-SNP guest */
 bool is_snpguest_supported(void)
 {
+#ifndef SGX
 	return !!(read_msr(SEV_STATUS_MSR) & (1 << SEV_SNP_FLAG));
+#else
+	return false;
+#endif
 }

--- a/src/verifiers/CMakeLists.txt
+++ b/src/verifiers/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_subdirectory(nullverifier)
 add_subdirectory(sgx-ecdsa)
-add_subdirectory(sev-snp)
+
+if(HOST)
+    add_subdirectory(sev-snp)
+endif()
 
 if(TDX)
     add_subdirectory(tdx-ecdsa)


### PR DESCRIPTION
Fix the sgx build mode error as follows.
rats-tls/src/core/cpu.c:197:34: error: 'O_RDONLY' undeclared (first use in this function)
  int fd = open("/dev/cpu/0/msr", O_RDONLY);

In addition, sev-snp attester and verifier are built only in host mode.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>