### PR TITLE
tls_wrappers/openssl: print verbose error about pre-verification failure

### DIFF
--- a/src/tls_wrappers/openssl/un_negotiate.c
+++ b/src/tls_wrappers/openssl/un_negotiate.c
@@ -327,8 +327,9 @@ int verify_certificate(int preverify, X509_STORE_CTX *ctx)
 
 	if (preverify == 0) {
 		int err = X509_STORE_CTX_get_error(ctx);
+
 		if (err != X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) {
-			RTLS_ERR("This is not a self-signed cert\n");
+			RTLS_ERR("Failed on pre-verification due to %d\n", err);
 			return 0;
 		}
 	}


### PR DESCRIPTION
The verbose error message is helpful to confirm the root
cause about pre-verification failure.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>