### PR TITLE
tls_wrappers/openssl: fix build warnings with openssl 1.0.x

### DIFF
--- a/src/tls_wrappers/openssl/openssl.h
+++ b/src/tls_wrappers/openssl/openssl.h
@@ -48,5 +48,9 @@ static inline void print_openssl_err(SSL *ssl, int ret)
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 extern int X509_STORE_get_ex_new_index(long argl, void *argp, CRYPTO_EX_new *new_func,
 				       CRYPTO_EX_dup *dup_func, CRYPTO_EX_free *free_func);
+extern const STACK_OF(X509_EXTENSION) * X509_get0_extensions(const X509 *x);
+extern int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data);
+extern void *X509_STORE_get_ex_data(const X509_STORE *ctx, int idx);
+extern X509_STORE *X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx);
 #endif
 #endif


### PR DESCRIPTION
Some functions are not exported and thus cause the following build
warnings:

/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c: In function 'find_oid':
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c:124:21: warning: implicit declaration of function 'X509_get0_extensions'; did you mean 'X509_REQ_get_extensions'? [-Wimplicit-function-declaration]
  124 |  if (!(extensions = X509_get0_extensions(crt))) {
      |                     ^~~~~~~~~~~~~~~~~~~~
      |                     X509_REQ_get_extensions
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c:124:19: warning: assignment to 'const struct stack_st_X509_EXTENSION *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  124 |  if (!(extensions = X509_get0_extensions(crt))) {
      |                   ^
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c: In function 'find_extension_from_cert':
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c:169:19: warning: assignment to 'const struct stack_st_X509_EXTENSION *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  169 |  if (!(extensions = X509_get0_extensions(cert))) {
      |                   ^
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c: In function 'verify_certificate':
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c:301:31: warning: implicit declaration of function 'X509_STORE_get_ex_data'; did you mean 'X509_STORE_CTX_get_ex_data'? [-Wimplicit-function-declaration]
  301 |  tls_wrapper_ctx_t *tls_ctx = X509_STORE_get_ex_data(cert_store, *ex_data);
      |                               ^~~~~~~~~~~~~~~~~~~~~~
      |                               X509_STORE_CTX_get_ex_data
/root/rats-tls/src/tls_wrappers/openssl/un_negotiate.c:301:31: warning: initialization of 'tls_wrapper_ctx_t *' {aka 'struct tls_wrapper_ctx *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>