### PR TITLE
Fix the conflict between KVM_HC_VM_ATTESTATION  and KVM_HC_MAP_GPA_RANGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Note that if you want to run SEV-SNP remote attestation, please refer to [link](
 
 **Notice: special prerequisites for CSV(2) remote attestation in software capability.**
 
-- Kernel support CSV(2) runtime attestation, please manually apply [theses patches](https://gitee.com/anolis/cloud-kernel/pulls/108)
+- Kernel support CSV(2) runtime attestation, please manually apply [theses patches](https://gitee.com/anolis/cloud-kernel/pulls/412)
 
 ## Specify the instance type
 

--- a/src/attesters/csv/collect_evidence.c
+++ b/src/attesters/csv/collect_evidence.c
@@ -117,7 +117,7 @@ static int load_hsk_cek_cert(uint8_t *hsk_cek_cert, const char *chip_id)
 }
 
 #define CSV_GUEST_MAP_LEN	 4096
-#define KVM_HC_VM_ATTESTATION	 12	/* Specific to HYGON CPU */
+#define KVM_HC_VM_ATTESTATION	 100	/* Specific to HYGON CPU */
 
 typedef struct {
 	unsigned char data[CSV_ATTESTATION_USER_DATA_SIZE];


### PR DESCRIPTION
csv attester need KVM_HC_VM_ATTESTATION to support communication between csv guest and host(i.e. KVM). The former definition of KVM_HC_VM_ATTESTATION conflicts with KVM_HC_MAP_GPA_RANGE which have introduced in linux mainline.
This patch fixes the definition of KVM_HC_VM_ATTESTATION to avoid the above conflicts.