### PR TITLE
attesters/csv: Fix KVM_HC_VM_ATTESTATION to avoid potential conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Note that if you want to run SEV-SNP remote attestation, please refer to [link](
 
 **Notice: special prerequisites for CSV(2) remote attestation in software capability.**
 
-- Kernel support CSV(2) runtime attestation, please manually apply [theses patches](https://gitee.com/anolis/cloud-kernel/pulls/108)
+- Kernel support CSV(2) runtime attestation, please manually apply [theses patches](https://gitee.com/anolis/cloud-kernel/pulls/412)
 
 ## Specify the instance type
 

--- a/src/attesters/csv/collect_evidence.c
+++ b/src/attesters/csv/collect_evidence.c
@@ -117,7 +117,7 @@ static int load_hsk_cek_cert(uint8_t *hsk_cek_cert, const char *chip_id)
 }
 
 #define CSV_GUEST_MAP_LEN	 4096
-#define KVM_HC_VM_ATTESTATION	 12	/* Specific to HYGON CPU */
+#define KVM_HC_VM_ATTESTATION	 100	/* Specific to HYGON CPU */
 
 typedef struct {
 	unsigned char data[CSV_ATTESTATION_USER_DATA_SIZE];


### PR DESCRIPTION
KVM_HC_VM_ATTESTATION is one of the hypercall interface between csv
guest and KVM. Since linux upstream has introduced KVM_HC_MAP_GPA_RANGE
as 12, the current definition of KVM_HC_VM_ATTESTATION may invalid when
csv guest hosting on newer linux.

Define KVM_HC_VM_ATTESTATION as 100 to avoid conflicts with
KVM_HC_MAP_GPA_RANGE.