### PR TITLE
rats-tls: add sgx-ecdsa attester in SGX mode

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -26,11 +26,11 @@ rats_tls_log_level_t global_log_level = RATS_TLS_LOG_LEVEL_DEFAULT;
 
 #ifdef SGX
 // clang-format off
-#define INSTANCE_NUM  7
+#define INSTANCE_NUM  8
 #define INSTANCE_NAME 32
 // clang-format off
 char enclave_instance_name[INSTANCE_NUM][INSTANCE_NAME] = { "nullcrypto",    "nullattester",
-							    "nullverifier",
+							    "nullverifier",  "sgx_ecdsa",
 							    "sgx_ecdsa_qve", "sgx_la",
 							    "nulltls",	     "openssl" };
 void librats_tls_init(void)

--- a/src/core/rtls_common.c
+++ b/src/core/rtls_common.c
@@ -100,17 +100,11 @@ rats_tls_err_t rtls_instance_init(const char *name, __attribute__((unused)) cons
                 err = rtls_enclave_verifier_post_init(name, NULL);
                 if (err != RATS_TLS_ERR_NONE)
                         return err;
-#ifndef SGX
         } else if (!strcmp(name, "sgx_ecdsa")) {
 		libattester_sgx_ecdsa_init();
-		libverifier_sgx_ecdsa_init();
                 err = rtls_enclave_attester_post_init(name, NULL);
                 if (err != RATS_TLS_ERR_NONE)
                         return err;
-                err = rtls_enclave_verifier_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-#endif
 	} else if (!strcmp(name, "sgx_ecdsa_qve")) {
 		libverifier_sgx_ecdsa_qve_init();
                 err = rtls_enclave_verifier_post_init(name, NULL);


### PR DESCRIPTION
sgx-ecdsa verifier can't be used in SGX mode. please
use sgx-ecdsa-qve instead.

Signed-off-by: Liang Yang <liang3.yang@intel.com>