### PR TITLE
Dev local

### DIFF
--- a/samples/rats-tls-client/client.c
+++ b/samples/rats-tls-client/client.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample client program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:m:l:i:p:D:E:h";
+	char *const short_options = "a:v:t:c:ml:i:p:D:E:h";
 	// clang-format off
 	struct option long_options[] = {
 		{ "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-client/client.c
+++ b/samples/rats-tls-client/client.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample client program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	char *const short_options = "a:v:t:c:m:l:i:p:D:h";
 	// clang-format off
 	struct option long_options[] = {
 		{ "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-client/client.c
+++ b/samples/rats-tls-client/client.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample client program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:ml:i:p:D:E:h";
+	char *const short_options = "a:v:t:c:ml:i:p:DEh";
 	// clang-format off
 	struct option long_options[] = {
 		{ "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-client/client.c
+++ b/samples/rats-tls-client/client.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample client program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:m:l:i:p:D:h";
+	char *const short_options = "a:v:t:c:m:l:i:p:D:E:h";
 	// clang-format off
 	struct option long_options[] = {
 		{ "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-server/server.c
+++ b/samples/rats-tls-server/server.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample server program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	char *const short_options = "a:v:t:c:ml:i:p:Dh";
 	// clang-format off
         struct option long_options[] = {
                 { "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-server/server.c
+++ b/samples/rats-tls-server/server.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample server program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	char *const short_options = "a:v:t:c:m:l:i:p:D:h";
 	// clang-format off
         struct option long_options[] = {
                 { "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-server/server.c
+++ b/samples/rats-tls-server/server.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample server program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:m:l:i:p:D:h";
+	char *const short_options = "a:v:t:c:ml:i:p:D:h";
 	// clang-format off
         struct option long_options[] = {
                 { "attester", required_argument, NULL, 'a' },


### PR DESCRIPTION
There are some improvements for the rats-tls samples/code like the followings：
```
char *const short_options = "a:v:t:c:ml:i:p:D:h";

```
The following expression may be better:
```
char *const short_options = "a:v:t:c:m:l:i:p:D:E:h";
```
