### PR TITLE
rats-tls:fix spelling mistake in rats-tls sample code

### DIFF
--- a/samples/rats-tls-client/client.c
+++ b/samples/rats-tls-client/client.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample client program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	char *const short_options = "a:v:t:c:ml:i:p:DEh";
 	// clang-format off
 	struct option long_options[] = {
 		{ "attester", required_argument, NULL, 'a' },

--- a/samples/rats-tls-server/server.c
+++ b/samples/rats-tls-server/server.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 	printf("    - Welcome to RATS-TLS sample server program\n");
 #endif
 
-	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	char *const short_options = "a:v:t:c:ml:i:p:Dh";
 	// clang-format off
         struct option long_options[] = {
                 { "attester", required_argument, NULL, 'a' },


### PR DESCRIPTION
There are some improvements for the rats-tls samples code.
For the "client.c" file : 
```
char *const short_options = "a:v:t:c:ml:i:p:D:h";
//the following expression may be better: 
char *const short_options = "a:v:t:c:ml:i:p:DEh";
```

For the "server.c" file : 
```
char *const short_options = "a:v:t:c:ml:i:p:D:h";
//the following expression may be better:
char *const short_options = "a:v:t:c:ml:i:p:Dh";
```