### PR TITLE
feature: using the fixed validity of tls cert, the preparation for th…

### DIFF
--- a/src/tls_wrappers/openssl/un_negotiate.c
+++ b/src/tls_wrappers/openssl/un_negotiate.c
@@ -293,6 +293,10 @@ int verify_certificate(int preverify, X509_STORE_CTX *ctx)
 {
 #endif
 
+/*
+* This code allows you to use command "openssl x509 -in /tmp/cert.der -inform der -text -noout"
+* to dump the content of TLS certificate with evidence extension.
+*/
 #if 0
 #ifndef SGX
 	X509 *crt = X509_STORE_CTX_get_current_cert(ctx);


### PR DESCRIPTION
This commit is related to  #issue104.
With a nonce mechanism, it is better to use the fixed validity of tls certificate, which can reduces unnecessary compatibility errors for validity check.
Without a nonce mechanism, use the current validity generation strategy to ensure security.