### PR TITLE
core/cpu.c: avoid printing error message during SEV platform detection

### DIFF
--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -204,7 +204,7 @@ static uint64_t read_msr(uint32_t reg)
 	uint64_t data;
 	if (pread(fd, &data, sizeof(data), reg) != sizeof(data)) {
 		close(fd);
-		RTLS_ERR("failed to read msr %#x\n", reg);
+		RTLS_DEBUG("failed to read msr %#x\n", reg);
 		return 0;
 	}
 


### PR DESCRIPTION
This message is just for debug purpose. If current platform is not a SEV platform, this message printed in error manner is totally confused.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>