### PR TITLE
attesters/sgx-ecdsa: fix sgx-ecdsa/sgx-la attesters to allow userdata larger than 32 bytes

### DIFF
--- a/src/attesters/sgx-la/collect_evidence.c
+++ b/src/attesters/sgx-la/collect_evidence.c
@@ -11,7 +11,7 @@
 #include <sgx_report.h>
 #include "sgx_la.h"
 
-extern sgx_status_t sgx_generate_evidence(uint8_t *hash, sgx_report_t *app_report);
+extern sgx_status_t sgx_generate_evidence(sgx_report_data_t *report_data, sgx_report_t *app_report);
 
 /* The local attestation requires to exchange the target info between ISV
  * enclaves as the prerequisite. This is out of scope in rats-tls because it
@@ -25,13 +25,22 @@ extern sgx_status_t sgx_generate_evidence(uint8_t *hash, sgx_report_t *app_repor
 enclave_attester_err_t sgx_la_collect_evidence(enclave_attester_ctx_t *ctx,
 					       attestation_evidence_t *evidence,
 					       rats_tls_cert_algo_t algo, uint8_t *hash,
-					       __attribute__((unused)) uint32_t hash_len)
+					       uint32_t hash_len)
 {
 	RTLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n", ctx, evidence, algo, hash);
 
+	sgx_report_data_t report_data;
+	if (sizeof(report_data.d) < hash_len) {
+		RTLS_ERR("hash_len(%zu) shall be smaller than user-data filed size (%zu)\n",
+			 hash_len, sizeof(report_data.d));
+		return ENCLAVE_ATTESTER_ERR_INVALID;
+	}
+	memset(&report_data, 0, sizeof(sgx_report_data_t));
+	memcpy(report_data.d, hash, hash_len);
+
 	sgx_report_t isv_report;
 	sgx_status_t generate_evidence_ret;
-	generate_evidence_ret = sgx_generate_evidence(hash, &isv_report);
+	generate_evidence_ret = sgx_generate_evidence(&report_data, &isv_report);
 	if (generate_evidence_ret != SGX_SUCCESS) {
 		RTLS_ERR("failed to generate evidence %#x\n", generate_evidence_ret);
 		return SGX_LA_ATTESTER_ERR_CODE((int)generate_evidence_ret);


### PR DESCRIPTION
This pull request removes the restriction on `hash_len` in the sgx-ecdsa/sgx-la attester, which previously assumed that the incoming `hash_len` must be 32 bytes. However, due to the new interoperable RA-TLS cert proposal, the `pubkey-hash-value` embedded in the report is not a sha256 hash value, but a cbor structure with a size larger than 32 bytes. Therefore, this submission is intended to remove this restriction in order to support the new proposal.

`Signed-off-by: Kun Lai <me@imlk.top>`