### PR TITLE
CMakeLists.txt: enable generating compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.5.1)
 project(rats-tls)
 set(RTLS_LIB rats_tls)
 set(RTLS_SRC_PATH ${CMAKE_CURRENT_LIST_DIR})
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Software version
 file(STRINGS "VERSION" RATS_TLS_VERSION)


### PR DESCRIPTION
Added a new option to CMakeLists.txt that enables the generation of compile_commands.json. This file can be used by IDEs and other tools to provide more accurate code completion and other features

`Signed-off-by: Kun Lai <me@imlk.top>`