### PR TITLE
openssl/un_negotiate: fix skipped cert verification in SGX mode

### DIFF
--- a/src/api/rats_tls_receive.c
+++ b/src/api/rats_tls_receive.c
@@ -13,7 +13,7 @@ rats_tls_err_t rats_tls_receive(rats_tls_handle handle, void *buf, size_t *buf_s
 {
 	rtls_core_context_t *ctx = (rtls_core_context_t *)handle;
 
-	RTLS_DEBUG("handle %p, buf %p, buf_size %p (%Zd-byte)\n", ctx, buf, buf_size, *buf_size);
+	RTLS_DEBUG("handle %p, buf %p, buf_size %p (%zu-byte)\n", ctx, buf, buf_size, *buf_size);
 
 	if (!handle || !handle->tls_wrapper || !handle->tls_wrapper->opts ||
 	    !handle->tls_wrapper->opts->receive || !buf || !buf_size)

--- a/src/api/rats_tls_transmit.c
+++ b/src/api/rats_tls_transmit.c
@@ -13,7 +13,7 @@ rats_tls_err_t rats_tls_transmit(rats_tls_handle handle, void *buf, size_t *buf_
 {
 	rtls_core_context_t *ctx = (rtls_core_context_t *)handle;
 
-	RTLS_DEBUG("handle %p, buf %p, buf_size %p (%Zd-byte)\n", ctx, buf, buf_size, *buf_size);
+	RTLS_DEBUG("handle %p, buf %p, buf_size %p (%zu-byte)\n", ctx, buf, buf_size, *buf_size);
 
 	if (!handle || !handle->tls_wrapper || !handle->tls_wrapper->opts ||
 	    !handle->tls_wrapper->opts->transmit || !buf || !buf_size)

--- a/src/tls_wrappers/openssl/un_negotiate.c
+++ b/src/tls_wrappers/openssl/un_negotiate.c
@@ -281,14 +281,11 @@ int openssl_extract_x509_extensions(X509 *crt, attestation_evidence_t *evidence)
 	return SSL_SUCCESS;
 }
 
-#ifdef SGX
-int verify_certificate(X509_STORE_CTX *ctx)
-{
-	int preverify_ok = 0;
-#else
 int verify_certificate(int preverify_ok, X509_STORE_CTX *ctx)
 {
-#endif
+	RTLS_DEBUG(
+		"verify_certificate preverify_ok: %d, ctx: %p, X509_STORE_CTX_get_error(ctx): %d\n",
+		preverify_ok, ctx, X509_STORE_CTX_get_error(ctx));
 
 /*
 * This code allows you to use command "openssl x509 -in /tmp/cert.der -inform der -text -noout"
@@ -322,7 +319,6 @@ int verify_certificate(int preverify_ok, X509_STORE_CTX *ctx)
 #endif
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	X509_STORE *cert_store = X509_STORE_CTX_get0_store(ctx);
 	int *ex_data = per_thread_getspecific();
 	if (!ex_data) {
@@ -335,21 +331,6 @@ int verify_certificate(int preverify_ok, X509_STORE_CTX *ctx)
 		RTLS_ERR("failed to get tls_wrapper_ctx pointer\n");
 		return 0;
 	}
-
-#else
-	X509_STORE *cert_store = X509_STORE_CTX_get0_store(ctx);
-	int *ex_data = per_thread_getspecific();
-	if (!ex_data) {
-		RTLS_ERR("failed to get ex_data\n");
-		return 0;
-	}
-
-	tls_wrapper_ctx_t *tls_ctx = X509_STORE_get_ex_data(cert_store, *ex_data);
-	if (!tls_ctx) {
-		RTLS_ERR("failed to get tls_wrapper_ctx pointer\n");
-		return 0;
-	}
-#endif
 
 	X509 *cert = X509_STORE_CTX_get_current_cert(ctx);
 	if (!cert) {


### PR DESCRIPTION
As a follow-up to PR #122, this commit addresses an issue where certificate extension verification was skipped when running in SGX mode, . It also fixes an error with the format string used in log prints.

`Signed-off-by: Kun Lai <me@imlk.top>`