### PR TITLE
.github/workflows: update compilation image to anolis 8.6

### DIFF
--- a/.github/workflows/docker/Dockerfile-compilation-testing-anolis8.6
+++ b/.github/workflows/docker/Dockerfile-compilation-testing-anolis8.6
@@ -1,4 +1,4 @@
-FROM openanolis/anolisos:8.4-x86_64
+FROM openanolis/anolisos:8.6-x86_64
 
 LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 
@@ -13,24 +13,24 @@ WORKDIR /root
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 ENV PATH         /root/.cargo/bin:$PATH
 
-ENV SGX_SDK_VERSION 2.15.1
-ENV SGX_SDK_RELEASE_NUMBER 2.15.101.1
+ENV SGX_SDK_VERSION 2.18
+ENV SGX_SDK_RELEASE_NUMBER 2.18.100.3
 
 # install LVI binutils for rats-tls build
 RUN wget https://download.01.org/intel-sgx/sgx-linux/$SGX_SDK_VERSION/as.ld.objdump.r4.tar.gz && \
-    tar -zxvf as.ld.objdump.r4.tar.gz && cp -rf external/toolset/centos8.2/* /usr/local/bin/ && \
+    tar -zxvf as.ld.objdump.r4.tar.gz && cp -rf external/toolset/anolis8.6/* /usr/local/bin/ && \
     rm -rf external && rm -rf as.ld.objdump.r4.tar.gz
 
 # install SGX
 RUN [ ! -f sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin ] && \
-    wget -c https://mirrors.openanolis.cn/inclavare-containers/bin/anolis8.4/sgx-$SGX_SDK_VERSION/sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
+    wget https://download.01.org/intel-sgx/latest/linux-latest/distro/Anolis86/sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
     chmod +x sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && echo -e 'n\n\/opt/intel\n' | ./sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin && \
     source /opt/intel/sgxsdk/environment && \
     rm -rf sgx_linux_x64_sdk_$SGX_SDK_RELEASE_NUMBER.bin
 
 RUN [ ! -f sgx_rpm_local_repo.tgz ] && \
-    wget -c https://mirrors.openanolis.cn/inclavare-containers/bin/anolis8.4/sgx-$SGX_SDK_VERSION/sgx_rpm_local_repo.tar.gz && \
-    tar zxvf sgx_rpm_local_repo.tar.gz && \
+    wget https://download.01.org/intel-sgx/latest/linux-latest/distro/Anolis86/sgx_rpm_local_repo.tgz && \
+    tar zxvf sgx_rpm_local_repo.tgz && \
     dnf config-manager --add-repo sgx_rpm_local_repo && \
     dnf makecache && rm -rf sgx_rpm_local_repo.tgz
 

--- a/.github/workflows/manually_compilation_testing_image.yml
+++ b/.github/workflows/manually_compilation_testing_image.yml
@@ -8,7 +8,7 @@ jobs:
     # Run all steps in the compilation testing containers
     strategy:
       matrix:
-        os: [anolis8.4, ubuntu20.04]
+        os: [anolis8.6, ubuntu20.04]
         
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/pr_basic_compilation_check.yml
+++ b/.github/workflows/pr_basic_compilation_check.yml
@@ -7,7 +7,7 @@ jobs:
     # Run all steps in the compilation testing containers
     strategy:
       matrix:
-        tag: [anolis8.4, ubuntu20.04]
+        tag: [anolis8.6, ubuntu20.04]
 
     container: runetest/compilation-testing:${{ matrix.tag }}
 


### PR DESCRIPTION
Use the sgx-linux release package of anolis 8.6 officially provided by intel to update the Anolis compilation test image.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>