### PR TITLE
attesters/sgx-ecdsa: add check for quote_size

### DIFF
--- a/src/attesters/sgx-ecdsa/collect_evidence.c
+++ b/src/attesters/sgx-ecdsa/collect_evidence.c
@@ -111,6 +111,13 @@ enclave_attester_err_t sgx_ecdsa_collect_evidence(enclave_attester_ctx_t *ctx,
 		return SGX_ECDSA_ATTESTER_ERR_CODE((int)qe3_ret);
 	}
 
+	if (quote_size > sizeof(evidence->ecdsa.quote)) {
+		RTLS_ERR(
+			"The value of quote_size exceeds the maximum quote size. quote_size: %u, maximum quote size: %u\n",
+			quote_size, sizeof(evidence->ecdsa.quote));
+		return ENCLAVE_ATTESTER_ERR_INVALID;
+	}
+
 	sgx_status = ocall_qe_get_quote(&qe3_ret, &app_report, quote_size, evidence->ecdsa.quote);
 	if (SGX_SUCCESS != sgx_status || ENCLAVE_ATTESTER_ERR_NONE != qe3_ret) {
 		RTLS_ERR("sgx_qe_get_quote(): 0x%04x, 0x%04x\n", sgx_status, qe3_ret);


### PR DESCRIPTION
The `quote_size` is from outside the enclave. A malicious `quote_size` value would cause an out-of-bounds reading of data inside the enclave when call `ocall_qe_get_quote()`. Add this check to prevent this problem.

Signed-off-by: Kun Lai <me@imlk.top>