### PR TITLE
Unify the format of evidence_buffer

### DIFF
--- a/src/include/internal/dice.h
+++ b/src/include/internal/dice.h
@@ -36,11 +36,6 @@ const uint8_t *evidence_get_raw_as_ref(const attestation_evidence_t *evidence, s
 int evidence_from_raw(const uint8_t *data, size_t size, uint64_t tag,
 		      attestation_evidence_t *evidence);
 
-enclave_attester_err_t
-dice_generate_pubkey_hash_value_buffer(const uint8_t *pubkey_hash,
-				       uint8_t **pubkey_hash_value_buffer,
-				       size_t *pubkey_hash_value_buffer_size);
-
 enclave_attester_err_t dice_generate_claims_buffer(const uint8_t *pubkey_hash,
 						   const claim_t *custom_claims,
 						   size_t custom_claims_length,
@@ -66,10 +61,6 @@ enclave_verifier_err_t
 dice_parse_endorsements_buffer_with_tag(const char *type, const uint8_t *endorsements_buffer,
 					size_t endorsements_buffer_size,
 					attestation_endorsement_t *endorsements);
-
-enclave_verifier_err_t dice_parse_and_verify_pubkey_hash(const uint8_t *pubkey_hash,
-							 const uint8_t *pubkey_hash_value_buffer,
-							 size_t pubkey_hash_value_buffer_size);
 
 enclave_verifier_err_t dice_parse_and_verify_claims_buffer(const uint8_t *pubkey_hash,
 							   const uint8_t *claims_buffer,

--- a/src/tls_wrappers/openssl/un_negotiate.c
+++ b/src/tls_wrappers/openssl/un_negotiate.c
@@ -260,10 +260,9 @@ static tls_wrapper_err_t verify_evidence_buffer(
 		RTLS_DEBUG("custom_claims %p, claims_size %zu\n", custom_claims,
 			   custom_claims_length);
 		for (size_t i = 0; i < custom_claims_length; ++i) {
-			RTLS_DEBUG(
-				"custom_claims[%zu] -> name: '%s' value_size: %zu value: '%.*s'\n",
-				i, custom_claims[i].name, custom_claims[i].value_size,
-				(int)custom_claims[i].value_size, custom_claims[i].value);
+			RTLS_DEBUG("custom_claims[%zu] -> name: '%s' value_size: %zu\n", i,
+				   custom_claims[i].name, custom_claims[i].value_size,
+				   (int)custom_claims[i].value_size);
 		}
 	}
 


### PR DESCRIPTION
The initial implementation of `evidence_buffer` has two forms. The first one is to put `<pubkey-hash>` into the userdata field of the evidence. The second is to put `<pubkey-hash>` into the claims_buffer.

This commit removes support for the first form, since it [has been deleted](https://github.com/CCC-Attestation/interoperable-ra-tls/blob/a2c2323377007aa27b5ceb453a741a860e0245a0/docs/Interoperable%20Attested%20TLS%5CInteroperable-RA-TLS-SGX-TDX-evidence-formats.md?plain=1#L22-L25) in the Interoperable RA-TLS proposal.

Signed-off-by: Kun Lai <me@imlk.top>