### PR TITLE
openssl/gen_cert: mark evidence extension as non-critical

### DIFF
--- a/src/crypto_wrappers/openssl/gen_cert.c
+++ b/src/crypto_wrappers/openssl/gen_cert.c
@@ -195,7 +195,7 @@ crypto_wrapper_err_t openssl_gen_cert(crypto_wrapper_ctx_t *ctx, rats_tls_cert_a
 	/* Add evidence extension */
 	if (cert_info->evidence_buffer_size) {
 		/* The DiceTaggedEvidence extension criticality flag SHOULD be marked critical. */
-		if (!x509_extension_add(cert, TCG_DICE_TAGGED_EVIDENCE_OID, true,
+		if (!x509_extension_add(cert, TCG_DICE_TAGGED_EVIDENCE_OID, false,
 					cert_info->evidence_buffer,
 					cert_info->evidence_buffer_size) != RATS_TLS_ERR_NONE)
 			goto err;
@@ -203,7 +203,7 @@ crypto_wrapper_err_t openssl_gen_cert(crypto_wrapper_ctx_t *ctx, rats_tls_cert_a
 
 	/* Add endorsements extension */
 	if (cert_info->endorsements_buffer_size) {
-		if (!x509_extension_add(cert, TCG_DICE_ENDORSEMENT_MANIFEST_OID, true,
+		if (!x509_extension_add(cert, TCG_DICE_ENDORSEMENT_MANIFEST_OID, false,
 					cert_info->endorsements_buffer,
 					cert_info->endorsements_buffer_size) != RATS_TLS_ERR_NONE)
 			goto err;

--- a/src/tls_wrappers/openssl/un_negotiate.c
+++ b/src/tls_wrappers/openssl/un_negotiate.c
@@ -178,6 +178,7 @@ int verify_certificate(int preverify_ok, X509_STORE_CTX *ctx)
 		if (err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT)
 			return SSL_SUCCESS;
 
+#if 0
 		/* According to the dice standard, the DiceTaggedEvidence extension should be set to critical=true.
 		 * However, there is no way via the openssl api to know directly which extension is causing
 		 * X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION, so we have to tolerate all this cases here.
@@ -188,6 +189,7 @@ int verify_certificate(int preverify_ok, X509_STORE_CTX *ctx)
 		 */
 		if (err == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION)
 			return SSL_SUCCESS;
+#endif
 
 		/*
 		 * A typical and unrecoverable error code is


### PR DESCRIPTION
Mark evidence extensions as `non-critical`, since many TLS libraries (such as openssl or mbedtls) do not support extracting critical extensions.

See: https://github.com/CCC-Attestation/interoperable-ra-tls/issues/9

Signed-off-by: Kun Lai <me@imlk.top>