### PR TITLE
CMakeLists.txt: fix include dirs and missing dependencies

### DIFF
--- a/samples/sgx-stub-enclave/CMakeLists.txt
+++ b/samples/sgx-stub-enclave/CMakeLists.txt
@@ -5,7 +5,7 @@ if(BUILD_SAMPLES)
     set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include/rats-tls
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include/edl
-                     ${CMAKE_BINARY_DIR}/../src/external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/include
+                     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/include
                      )
 
     set(LIBRARY_DIRS ${INTEL_SGXSSL_LIB_PATH}
@@ -71,6 +71,7 @@ set(DEPEND_TRUSTED_LIBS crypto_wrapper_nullcrypto
 
 add_enclave_library(sgx_stub_enclave SRCS ${E_SRCS} EDL ${EDLS} TRUSTED_LIBS ${DEPEND_TRUSTED_LIBS} EDL_SEARCH_PATHS ${EDL_SEARCH_PATHS} LDSCRIPT ${LDS})
 enclave_sign(sgx_stub_enclave KEY sgx_stub_enclave.pem CONFIG sgx_stub_enclave.xml)
+add_dependencies(sgx_stub_enclave rats_tls)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sgx_stub_enclave.signed.so
         DESTINATION /usr/share/rats-tls/samples)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,23 +8,26 @@ set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
 if(SGX)
     list(APPEND INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include/edl
                              ${CMAKE_BINARY_DIR}/src/sgx/trust
-                             ${CMAKE_BINARY_DIR}/../src/external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/include
                              )
 endif()
+
+# Add third party and instance directory
+add_subdirectory(attesters)
+add_subdirectory(verifiers)
+if(SGX)
+    add_subdirectory(sgx)
+endif()
+
+# Add third party library required by crypto_wrappers and tls_wrappers
+if(SGX)
+    list(APPEND INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/external/sgx-ssl/intel-sgx-ssl/src/intel-sgx-ssl/Linux/package/include)
+endif()
+add_subdirectory(crypto_wrappers)
+add_subdirectory(tls_wrappers)
 
 list(APPEND INCLUDE_DIRS ${LIBCBOR_INC_PATH})
 
 include_directories(${INCLUDE_DIRS})
-
-# Add third party and instance directory
-add_subdirectory(external)
-add_subdirectory(crypto_wrappers)
-add_subdirectory(attesters)
-add_subdirectory(verifiers)
-add_subdirectory(tls_wrappers)
-if(SGX)
-    add_subdirectory(sgx)
-endif()
 
 # Set source file
 set(SOURCES

--- a/src/api/rats_tls_init.c
+++ b/src/api/rats_tls_init.c
@@ -14,6 +14,7 @@
 #include "internal/tls_wrapper.h"
 #include "internal/attester.h"
 #include "internal/verifier.h"
+#include <openssl/opensslv.h>
 
 rats_tls_err_t rats_tls_init(const rats_tls_conf_t *conf, rats_tls_handle *handle)
 {
@@ -40,6 +41,15 @@ rats_tls_err_t rats_tls_init(const rats_tls_conf_t *conf, rats_tls_handle *handl
 		ctx->config.log_level = global_core_context.config.log_level;
 		RTLS_WARN("log level reset to global value %d\n",
 			  global_core_context.config.log_level);
+	}
+
+	/* FIXME: it is intended to use the certificate with different algorithm */
+	if (ctx->config.cert_algo == RATS_TLS_CERT_ALGO_DEFAULT) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+		ctx->config.cert_algo = RATS_TLS_CERT_ALGO_RSA_3072_SHA256;
+#else
+		ctx->config.cert_algo = RATS_TLS_CERT_ALGO_ECC_256_SHA256;
+#endif
 	}
 
 	if (ctx->config.cert_algo < 0 || ctx->config.cert_algo >= RATS_TLS_CERT_ALGO_MAX) {

--- a/src/attesters/sgx-ecdsa/CMakeLists.txt
+++ b/src/attesters/sgx-ecdsa/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES cleanup.c
 # Generate library
 if(SGX)
     add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES})
+    add_dependencies(${PROJECT_NAME} rtls_edl_t)
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
     target_link_libraries(${PROJECT_NAME} ${EXTRA_LINK_LIBRARY} ${RATS_TLS_LDFLAGS} ${RTLS_LIB})

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -17,6 +17,7 @@
 #ifdef SGX
 #include "rtls_t.h"
 #endif
+#include <openssl/opensslv.h>
 // clang-format on
 
 /* The global configurations present by /opt/rats-tls/config.toml */
@@ -54,7 +55,12 @@ void __attribute__((constructor)) librats_tls_init(void)
 	global_core_context.config.api_version = RATS_TLS_API_VERSION_DEFAULT;
 	// clang-format on
 	global_core_context.config.log_level = global_log_level;
-	global_core_context.config.cert_algo = RATS_TLS_CERT_ALGO_DEFAULT;
+	/* FIXME: it is intended to use the certificate with different algorithm */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	global_core_context.config.cert_algo = RATS_TLS_CERT_ALGO_RSA_3072_SHA256;
+#else
+	global_core_context.config.cert_algo = RATS_TLS_CERT_ALGO_ECC_256_SHA256;
+#endif
 
 	/* TODO: load and parse the global configuration file */
 

--- a/src/core/rtls_common.c
+++ b/src/core/rtls_common.c
@@ -33,12 +33,12 @@ extern void libverifier_sgx_la_init(void);
 extern void libtls_wrapper_nulltls_init(void);
 extern void libtls_wrapper_openssl_init(void);
 #endif
-//clang-format on
+// clang-format on
 
 #ifdef SGX
 void rtls_exit(void)
 {
-        ocall_exit();
+	ocall_exit();
 }
 
 rats_tls_log_level_t rtls_loglevel_getenv(const char *name)
@@ -47,90 +47,90 @@ rats_tls_log_level_t rtls_loglevel_getenv(const char *name)
 	size_t log_level_len = 32;
 
 	log_level_str = calloc(1, log_level_len);
-        if (!log_level_str) {
-                RTLS_ERR("failed to calloc log level string\n");
-                return -1;
-        }
+	if (!log_level_str) {
+		RTLS_ERR("failed to calloc log level string\n");
+		return -1;
+	}
 
 	ocall_getenv(name, log_level_str, log_level_len);
 	if (log_level_str) {
 		if (!strcmp(log_level_str, "debug") || !strcmp(log_level_str, "DEBUG")) {
-                        free(log_level_str);
+			free(log_level_str);
 			return RATS_TLS_LOG_LEVEL_DEBUG;
-                } else if (!strcmp(log_level_str, "info") || !strcmp(log_level_str, "INFO")) {
-                        free(log_level_str);
+		} else if (!strcmp(log_level_str, "info") || !strcmp(log_level_str, "INFO")) {
+			free(log_level_str);
 			return RATS_TLS_LOG_LEVEL_INFO;
-                } else if (!strcmp(log_level_str, "warn") || !strcmp(log_level_str, "WARN")) {
-                        free(log_level_str);
+		} else if (!strcmp(log_level_str, "warn") || !strcmp(log_level_str, "WARN")) {
+			free(log_level_str);
 			return RATS_TLS_LOG_LEVEL_WARN;
-                } else if (!strcmp(log_level_str, "error") || !strcmp(log_level_str, "ERROR")) {
-                        free(log_level_str);
+		} else if (!strcmp(log_level_str, "error") || !strcmp(log_level_str, "ERROR")) {
+			free(log_level_str);
 			return RATS_TLS_LOG_LEVEL_ERROR;
-                } else if (!strcmp(log_level_str, "fatal") || !strcmp(log_level_str, "FATAL")) {
-                        free(log_level_str);
+		} else if (!strcmp(log_level_str, "fatal") || !strcmp(log_level_str, "FATAL")) {
+			free(log_level_str);
 			return RATS_TLS_LOG_LEVEL_FATAL;
-                } else if (!strcmp(log_level_str, "off") || !strcmp(log_level_str, "OFF")) {
-                        free(log_level_str);
+		} else if (!strcmp(log_level_str, "off") || !strcmp(log_level_str, "OFF")) {
+			free(log_level_str);
 			return RATS_TLS_LOG_LEVEL_NONE;
-                }
+		}
 	}
 
 	return RATS_TLS_LOG_LEVEL_DEFAULT;
 }
 
 rats_tls_err_t rtls_instance_init(const char *name, __attribute__((unused)) const char *realpath,
-				     __attribute__((unused)) void **handle)
+				  __attribute__((unused)) void **handle)
 {
-        rats_tls_err_t err;
+	rats_tls_err_t err;
 
 	if (!strcmp(name, "nullcrypto")) {
 		libcrypto_wrapper_nullcrypto_init();
-                err = rtls_enclave_crypto_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-        } else if (!strcmp(name, "nullattester")) {
+		err = rtls_enclave_crypto_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+	} else if (!strcmp(name, "nullattester")) {
 		libattester_null_init();
-                err = rtls_enclave_attester_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-        } else if (!strcmp(name, "nullverifier")) {
+		err = rtls_enclave_attester_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+	} else if (!strcmp(name, "nullverifier")) {
 		libverifier_null_init();
-                err = rtls_enclave_verifier_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-        } else if (!strcmp(name, "sgx_ecdsa")) {
+		err = rtls_enclave_verifier_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+	} else if (!strcmp(name, "sgx_ecdsa")) {
 		libattester_sgx_ecdsa_init();
-                err = rtls_enclave_attester_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
+		err = rtls_enclave_attester_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
 	} else if (!strcmp(name, "sgx_ecdsa_qve")) {
 		libverifier_sgx_ecdsa_qve_init();
-                err = rtls_enclave_verifier_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-        } else if (!strcmp(name, "sgx_la")) {
+		err = rtls_enclave_verifier_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+	} else if (!strcmp(name, "sgx_la")) {
 		libattester_sgx_la_init();
 		libverifier_sgx_la_init();
-                 err = rtls_enclave_attester_post_init(name, NULL);
-                 if (err != RATS_TLS_ERR_NONE)
-                         return err;
-                 err = rtls_enclave_verifier_post_init(name, NULL);
-                 if (err != RATS_TLS_ERR_NONE)
-                         return err;
+		err = rtls_enclave_attester_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+		err = rtls_enclave_verifier_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
 	} else if (!strcmp(name, "nulltls")) {
 		libtls_wrapper_nulltls_init();
-                err = rtls_rats_tls_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-        } else if (!strcmp(name, "openssl")) {
+		err = rtls_rats_tls_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+	} else if (!strcmp(name, "openssl")) {
 		libtls_wrapper_openssl_init();
 		libcrypto_wrapper_openssl_init();
-                err = rtls_rats_tls_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
-                err = rtls_enclave_crypto_post_init(name, NULL);
-                if (err != RATS_TLS_ERR_NONE)
-                        return err;
+		err = rtls_rats_tls_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
+		err = rtls_enclave_crypto_post_init(name, NULL);
+		if (err != RATS_TLS_ERR_NONE)
+			return err;
 	} else
 		return RATS_TLS_ERR_NO_NAME;
 
@@ -176,10 +176,10 @@ int rtls_readdir(uint64_t dirp, rtls_dirent **ptr)
 	int ret = 0;
 
 	*ptr = (rtls_dirent *)calloc(1, sizeof(rtls_dirent));
-        if (!ptr) {
-                RTLS_ERR("failed to calloc memory in rtls_readdir\n");
-                return -1;
-        }
+	if (!ptr) {
+		RTLS_ERR("failed to calloc memory in rtls_readdir\n");
+		return -1;
+	}
 	ocall_readdir(&ret, dirp, *ptr);
 
 	return ret;
@@ -195,7 +195,7 @@ int rtls_closedir(uint64_t dir)
 #else
 void rtls_exit(void)
 {
-        exit(EXIT_FAILURE);
+	exit(EXIT_FAILURE);
 }
 
 rats_tls_log_level_t rtls_loglevel_getenv(const char *name)
@@ -220,7 +220,7 @@ rats_tls_log_level_t rtls_loglevel_getenv(const char *name)
 }
 
 rats_tls_err_t rtls_instance_init(const char *name, __attribute__((unused)) const char *realpath,
-				     __attribute__((unused)) void **handle)
+				  __attribute__((unused)) void **handle)
 {
 	*handle = dlopen(realpath, RTLD_LAZY);
 	if (*handle == NULL) {

--- a/src/crypto_wrappers/internal/rtls_crypto_wrapper_load_single.c
+++ b/src/crypto_wrappers/internal/rtls_crypto_wrapper_load_single.c
@@ -18,7 +18,7 @@
 #else
 #define PATTERN_SUFFIX ".so"
 #endif
-//clang-format on
+// clang-format on
 
 rats_tls_err_t rtls_enclave_crypto_post_init(const char *name, void *handle)
 {
@@ -56,7 +56,7 @@ rats_tls_err_t rtls_enclave_crypto_post_init(const char *name, void *handle)
 
 	crypto_wrappers_ctx[crypto_wrappers_nums++] = crypto_ctx;
 
-        return RATS_TLS_ERR_NONE;
+	return RATS_TLS_ERR_NONE;
 }
 
 rats_tls_err_t rtls_crypto_wrapper_load_single(const char *fname)
@@ -87,7 +87,7 @@ rats_tls_err_t rtls_crypto_wrapper_load_single(const char *fname)
 	if (err != RATS_TLS_ERR_NONE)
 		return err;
 
-        err = rtls_enclave_crypto_post_init(name, handle);
+	err = rtls_enclave_crypto_post_init(name, handle);
 	if (err != RATS_TLS_ERR_NONE)
 		return err;
 

--- a/src/crypto_wrappers/openssl/CMakeLists.txt
+++ b/src/crypto_wrappers/openssl/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES cleanup.c
 if(SGX)
     set(DEPEND_TRUSTED_LIBS sgx_tsgxssl_cryptod)
     add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES} TRUSTED_LIBS ${DEPEND_TRUSTED_LIBS})
+    add_dependencies(${PROJECT_NAME} intel-sgx-ssl)
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
     target_link_libraries(${PROJECT_NAME} ${RATS_TLS_LDFLAGS} ${RTLS_LIB} crypto.so)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1,3 +1,0 @@
-if(SGX)
-add_subdirectory(sgx-ssl)
-endif()

--- a/src/external/sgx-ssl/CMakeLists.txt
+++ b/src/external/sgx-ssl/CMakeLists.txt
@@ -1,8 +1,0 @@
-set(SGXSSL_SRC_PATH ${CMAKE_BINARY_DIR}/src/external/sgx-ssl/intel-sgx-ssl/src)
-set(SGXSSL_LIB_PATH ${SGXSSL_SRC_PATH}/intel-sgx-ssl/Linux/package/lib64)
-set(SGXSSL_INC_PATH ${SGXSSL_SRC_PATH}/intel-sgx-ssl/Linux/package/include)
-set(SGXSSL_LIB_FILES ${SGXSSL_LIB_PATH}/libsgx_usgxssl.a
-		     ${SGXSSL_LIB_PATH}/libsgx_tsgxssl.a
-                     ${SGXSSL_LIB_PATH}/libsgx_tsgxssl_ssl.a
-		     ${SGXSSL_LIB_PATH}/libsgx_tsgxssl_crypto.a
-                     )

--- a/src/include/rats-tls/api.h
+++ b/src/include/rats-tls/api.h
@@ -12,7 +12,6 @@
 #include <stddef.h>
 #include <rats-tls/err.h>
 #include <rats-tls/claim.h>
-#include <openssl/opensslv.h>
 
 #define TLS_TYPE_NAME_SIZE		32
 #define ENCLAVE_ATTESTER_TYPE_NAME_SIZE 32
@@ -37,12 +36,7 @@ typedef enum {
 	RATS_TLS_CERT_ALGO_RSA_3072_SHA256,
 	RATS_TLS_CERT_ALGO_ECC_256_SHA256,
 	RATS_TLS_CERT_ALGO_MAX,
-/* FIXME: it is intended to use the certificate with different algorithm */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	RATS_TLS_CERT_ALGO_DEFAULT = RATS_TLS_CERT_ALGO_RSA_3072_SHA256
-#else
-	RATS_TLS_CERT_ALGO_DEFAULT = RATS_TLS_CERT_ALGO_ECC_256_SHA256
-#endif
+	RATS_TLS_CERT_ALGO_DEFAULT,
 } rats_tls_cert_algo_t;
 
 typedef struct {

--- a/src/tls_wrappers/nulltls/CMakeLists.txt
+++ b/src/tls_wrappers/nulltls/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES cleanup.c
 # Generate library
 if(SGX)
     add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES})
+    add_dependencies(${PROJECT_NAME} rtls_edl_t)
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
     target_link_libraries(${PROJECT_NAME} ${RATS_TLS_LDFLAGS} ${RTLS_LIB})

--- a/src/tls_wrappers/nulltls/receive.c
+++ b/src/tls_wrappers/nulltls/receive.c
@@ -8,11 +8,6 @@
 #include <rats-tls/log.h>
 #include <internal/core.h>
 #include <rats-tls/tls_wrapper.h>
-// clang-format off
-#ifdef SGX
-#include "rtls_t.h"
-#endif
-// clang-format on
 
 tls_wrapper_err_t nulltls_receive(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {

--- a/src/tls_wrappers/nulltls/transmit.c
+++ b/src/tls_wrappers/nulltls/transmit.c
@@ -8,11 +8,6 @@
 #include <rats-tls/log.h>
 #include <rats-tls/tls_wrapper.h>
 #include <internal/core.h>
-// clang-format off
-#ifdef SGX
-#include "rtls_t.h"
-#endif
-// clang-format on
 
 tls_wrapper_err_t nulltls_transmit(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {

--- a/src/tls_wrappers/openssl/CMakeLists.txt
+++ b/src/tls_wrappers/openssl/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES cleanup.c
 if(SGX)
     set(DEPEND_TRUSTED_LIBS sgx_tsgxssl sgx_tsgxssl_ssl)
     add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES} TRUSTED_LIBS ${DEPEND_TRUSTED_LIBS})
+    add_dependencies(${PROJECT_NAME} intel-sgx-ssl)
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
     target_link_libraries(${PROJECT_NAME} ${RATS_TLS_LDFLAGS} ${RTLS_LIB} ssl)

--- a/src/verifiers/sgx-ecdsa-qve/CMakeLists.txt
+++ b/src/verifiers/sgx-ecdsa-qve/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES cleanup.c
 # Generate library
 if(SGX)
     add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES})
+    add_dependencies(${PROJECT_NAME} rtls_edl_t)
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
     target_link_libraries(${PROJECT_NAME} ${EXTRA_LINK_LIBRARY} ${RATS_TLS_LDFLAGS} ${RTLS_LIB})

--- a/src/verifiers/sgx-ecdsa/CMakeLists.txt
+++ b/src/verifiers/sgx-ecdsa/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES cleanup.c
 # Generate library
 if(SGX)
     add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES})
+    add_dependencies(${PROJECT_NAME} rtls_edl_t)
 else()
     add_library(${PROJECT_NAME} SHARED ${SOURCES})
     target_link_libraries(${PROJECT_NAME} ${EXTRA_LINK_LIBRARY} ${RATS_TLS_LDFLAGS} ${RTLS_LIB})

--- a/src/verifiers/sgx-la/CMakeLists.txt
+++ b/src/verifiers/sgx-la/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES cleanup.c
 
 # Generate library
 add_trusted_library(${PROJECT_NAME} SRCS ${SOURCES})
+add_dependencies(${PROJECT_NAME} rtls_edl_t)
 
 # Install library
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
This commit strengthens the dependencies between different cmake tergets and makes multi-threaded compilation (`make -j`) work correctly.

Signed-off-by: Kun Lai <me@imlk.top>
