### PR TITLE
attester/csv: return non-zero value if failed to get hsk_cek cert

### DIFF
--- a/src/attesters/csv/collect_evidence.c
+++ b/src/attesters/csv/collect_evidence.c
@@ -284,6 +284,7 @@ static int collect_attestation_evidence(uint8_t *hash, uint32_t hash_len,
 
 	if (csv_get_hsk_cek_cert((const char *)chip_id, evidence_buffer)) {
 		RTLS_ERR("failed to load HSK and CEK cert\n");
+		ret = -1;
 		goto err_munmap;
 	}
 	evidence->report_len = sizeof(csv_evidence);


### PR DESCRIPTION
This change fix spurious success if csv attester cannot get hsk_cek cert.