### PR TITLE
openssl/gen_cert: fix stack overflow on cert_buf

### DIFF
--- a/src/core/rtls_core_generate_certificate.c
+++ b/src/core/rtls_core_generate_certificate.c
@@ -102,11 +102,13 @@ rats_tls_err_t rtls_core_generate_certificate(rtls_core_context_t *ctx)
 			.organization = (const unsigned char *)"Inclavare Containers",
 			.common_name = (const unsigned char *)"RATS-TLS",
 		},
+		.cert_buf = NULL,
+		.cert_len = 0,
+		.evidence_buffer = NULL,
+		.evidence_buffer_size = 0,
+		.endorsements_buffer = NULL,
+		.endorsements_buffer_size = 0,
 	};
-	cert_info.evidence_buffer = NULL;
-	cert_info.evidence_buffer_size = 0;
-	cert_info.endorsements_buffer = NULL;
-	cert_info.endorsements_buffer_size = 0;
 
 	/* Get DICE evidence buffer */
 	/* This check is a workaround for the nullattester.
@@ -164,13 +166,21 @@ rats_tls_err_t rtls_core_generate_certificate(rtls_core_context_t *ctx)
 
 		t_err = ctx->tls_wrapper->opts->use_privkey(ctx->tls_wrapper, ctx->config.cert_algo,
 							    privkey_buf, privkey_len);
-		if (t_err != TLS_WRAPPER_ERR_NONE)
+		if (t_err != TLS_WRAPPER_ERR_NONE) {
+			if (cert_info.cert_buf)
+				free(cert_info.cert_buf);
 			return t_err;
+		}
 
 		t_err = ctx->tls_wrapper->opts->use_cert(ctx->tls_wrapper, &cert_info);
-		if (t_err != TLS_WRAPPER_ERR_NONE)
+		if (t_err != TLS_WRAPPER_ERR_NONE) {
+			if (cert_info.cert_buf)
+				free(cert_info.cert_buf);
 			return t_err;
+		}
 	}
+	if (cert_info.cert_buf)
+		free(cert_info.cert_buf);
 
 	/* Prevent from re-generation of TLS certificate */
 	ctx->flags |= RATS_TLS_CTX_FLAGS_CERT_CREATED;

--- a/src/crypto_wrappers/openssl/gen_cert.c
+++ b/src/crypto_wrappers/openssl/gen_cert.c
@@ -213,14 +213,15 @@ crypto_wrapper_err_t openssl_gen_cert(crypto_wrapper_ctx_t *ctx, rats_tls_cert_a
 	if (!X509_sign(cert, pkey, EVP_sha256()))
 		goto err;
 
-	der = cert_info->cert_buf;
-	len = i2d_X509(cert, &der);
+	cert_info->cert_buf = NULL;
+	len = i2d_X509(cert, &cert_info->cert_buf);
 	if (len < 0)
 		goto err;
 
 	cert_info->cert_len = len;
 
-	RTLS_DEBUG("self-signing certificate generated\n");
+	RTLS_DEBUG("self-signing certificate generated. cert_buf: %p, cert_len: %u\n",
+		   cert_info->cert_buf, cert_info->cert_len);
 
 	ret = CRYPTO_WRAPPER_ERR_NONE;
 

--- a/src/include/rats-tls/cert.h
+++ b/src/include/rats-tls/cert.h
@@ -77,7 +77,7 @@ typedef struct {
 typedef struct {
 	cert_subject_t subject;
 	unsigned int cert_len;
-	uint8_t cert_buf[8192];
+	uint8_t *cert_buf;
 	uint8_t *evidence_buffer;
 	size_t evidence_buffer_size;
 	uint8_t *endorsements_buffer;


### PR DESCRIPTION
A buffer of 8192 bytes in size is not enough for cert generation. The size of a typical certificate (with sgx-ecdsa endorsements extension) is 17718 bytes.