### PR TITLE
add a link to CSV runtime attestation patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Note that if you want to run SEV-SNP remote attestation, please refer to [link](
 
 **Notice: special prerequisites for CSV(2) remote attestation in software capability.**
 
-- Kernel support CSV(2) runtime attestation, please manually apply [theses patches](https://gitee.com/anolis/cloud-kernel/pulls/412)
+- Kernel support CSV(2) runtime attestation, please manually apply these patches [1](https://gitee.com/anolis/cloud-kernel/pulls/108) and [2](https://gitee.com/anolis/cloud-kernel/pulls/412).
 
 ## Specify the instance type
 


### PR DESCRIPTION
The CSV patches on Anolis supporting runtime attestation consist of [1](https://gitee.com/anolis/cloud-kernel/pulls/108) and [2](https://gitee.com/anolis/cloud-kernel/pulls/412). And main patch is the former while the latter only fixes a macro conflict.