### PR TITLE
src/CMakeLists.txt: Fix header file directory error and missing claim.h

### DIFF
--- a/samples/rats-tls-client/CMakeLists.txt
+++ b/samples/rats-tls-client/CMakeLists.txt
@@ -42,7 +42,6 @@ else()
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include/rats-tls
                      ${RATS_TLS_INSTALL_INCLUDE_PATH}
                      ${RATS_TLS_INSTALL_INCLUDE_PATH}/edl
-                     ${RATS_TLS_INSTALL_INCLUDE_PATH}/rats-tls
                      )
     set(LIBRARY_DIRS ${RATS_TLS_INSTALL_LIB_PATH})
 endif()

--- a/samples/rats-tls-server/CMakeLists.txt
+++ b/samples/rats-tls-server/CMakeLists.txt
@@ -42,7 +42,6 @@ else()
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../src/include/rats-tls
                      ${RATS_TLS_INSTALL_INCLUDE_PATH}
                      ${RATS_TLS_INSTALL_INCLUDE_PATH}/edl
-                     ${RATS_TLS_INSTALL_INCLUDE_PATH}/rats-tls
                      )
     set(LIBRARY_DIRS ${RATS_TLS_INSTALL_LIB_PATH})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ install(TARGETS ${RTLS_LIB}
 # Install header
 set(RTLS_INCLUDE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/api.h
                        ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/cert.h
+                       ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/claim.h
                        ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/crypto_wrapper.h
                        ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/attester.h
                        ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/verifier.h
@@ -118,6 +119,6 @@ set(RTLS_INCLUDE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/api.h
                        ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/tls_wrapper.h
                        ${CMAKE_CURRENT_SOURCE_DIR}/include/rats-tls/hash.h
                        )
-install(DIRECTORY DESTINATION ${RATS_TLS_INSTALL_INCLUDE_PATH}/rats-tls)
+install(DIRECTORY DESTINATION ${RATS_TLS_INSTALL_INCLUDE_PATH})
 install(FILES ${RTLS_INCLUDE_FILES}
-DESTINATION ${RATS_TLS_INSTALL_INCLUDE_PATH}/rats-tls)
+DESTINATION ${RATS_TLS_INSTALL_INCLUDE_PATH})


### PR DESCRIPTION
Original header file directory: /usr/local/include/rats-tls/rats-tls/
Now the header file directory: /usr/local/include/rats-tls/