### PR TITLE
dist: fix error header file directory path

### DIFF
--- a/dist/rpm/rats-tls-filelist
+++ b/dist/rpm/rats-tls-filelist
@@ -1,6 +1,6 @@
 /usr/share/rats-tls/samples/rats-tls-server
 /usr/share/rats-tls/samples/rats-tls-client
-/usr/local/include/rats-tls/rats-tls/*.h
+/usr/local/include/rats-tls/*.h
 /usr/local/lib/rats-tls/librats_tls.so*
 /usr/local/lib/rats-tls/tls-wrappers/libtls_wrapper*.so*
 /usr/local/lib/rats-tls/crypto-wrappers/libcrypto_wrapper*.so*

--- a/dist/rpm/rats-tls-sgx-filelist
+++ b/dist/rpm/rats-tls-sgx-filelist
@@ -1,7 +1,7 @@
 /usr/share/rats-tls/samples/rats-tls-server
 /usr/share/rats-tls/samples/rats-tls-client
 /usr/share/rats-tls/samples/sgx_stub_enclave.signed.so
-/usr/local/include/rats-tls/rats-tls/*.h
+/usr/local/include/rats-tls/*.h
 /usr/local/lib/rats-tls/librats_tls.a
 /usr/local/lib/rats-tls/librtls_edl_t.a
 /usr/local/lib/rats-tls/librats_tls_u.a


### PR DESCRIPTION
In https://github.com/inclavare-containers/rats-tls/pull/164, the header file directory changes to /usr/local/include/rats-tls/.